### PR TITLE
install 'rust-lang/rust.vim' in languages/rust.lua

### DIFF
--- a/lua/languages/rust.lua
+++ b/lua/languages/rust.lua
@@ -1,4 +1,5 @@
 return {
+	{ 'rust-lang/rust.vim' },
 	{
 		"simrat39/rust-tools.nvim",
 		lazy = true,


### PR DESCRIPTION
See https://github.com/rust-lang/rust.vim/issues/461#issuecomment-1005313227. There are some problems using `RustFmt` and `RustFmtRange`. The problems are solved after installing the latest version of plugin 'rust-lang/rust.vim'.